### PR TITLE
Make it possible to pass already hashed and based64 password, so no plain-text password is visible in the code/configs

### DIFF
--- a/AllegroWebAPI.php
+++ b/AllegroWebAPI.php
@@ -37,16 +37,16 @@ class AllegroWebAPI
         $countryId=AllegroWebAPI::COUNTRY_PL,
         $useSandbox=FALSE,
         $soapClientOptions=array('features' => SOAP_SINGLE_ELEMENT_ARRAYS),
-		$passwordAlreadyHashed = false
+        $passwordAlreadyHashed = false
     )
     {
         $this->webapiKey = $webapiKey;
         $this->login = $login;
-		if($passwordAlreadyHashed == false) {
-			$this->password = base64_encode(hash('sha256', $password, TRUE));
-		} else {
-			$this->password = $password;
-		}
+        if($passwordAlreadyHashed == false) {
+            $this->password = base64_encode(hash('sha256', $password, TRUE));
+        } else {
+            $this->password = $password;
+        }
         $this->countryId = $countryId;
 
         $wsdl = $useSandbox ? self::SANDBOX : self::WSDL;

--- a/AllegroWebAPI.php
+++ b/AllegroWebAPI.php
@@ -36,12 +36,17 @@ class AllegroWebAPI
         $password,
         $countryId=AllegroWebAPI::COUNTRY_PL,
         $useSandbox=FALSE,
-        $soapClientOptions=array('features' => SOAP_SINGLE_ELEMENT_ARRAYS)
+        $soapClientOptions=array('features' => SOAP_SINGLE_ELEMENT_ARRAYS),
+		$passwordAlreadyHashed = false
     )
     {
         $this->webapiKey = $webapiKey;
         $this->login = $login;
-        $this->password = base64_encode(hash('sha256', $password, TRUE));
+		if($passwordAlreadyHashed == false) {
+			$this->password = base64_encode(hash('sha256', $password, TRUE));
+		} else {
+			$this->password = $password;
+		}
         $this->countryId = $countryId;
 
         $wsdl = $useSandbox ? self::SANDBOX : self::WSDL;


### PR DESCRIPTION
Now the password is based64 and hashed in constructor, I wanted to make it possible to pass already hashed and encoded password, so it's not visible in the code or config files/db_tables.

I couldn't just inherit the class and change the constructor, becasuse important fields are privat.e